### PR TITLE
Add spotless gradle plugin for code formatting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
 }
+apply from: "$rootDir/spotless.gradle"
 
 android {
     compileSdkVersion 30

--- a/app/src/androidTest/java/com/mobile/android/template/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mobile/android/template/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.mobile.android.template
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/java/com/mobile/android/template/MainActivity.kt
+++ b/app/src/main/java/com/mobile/android/template/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.mobile.android.template
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/test/java/com/mobile/android/template/ExampleUnitTest.kt
+++ b/app/src/test/java/com/mobile/android/template/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.mobile.android.template
 
-import org.junit.Test
-
 import org.junit.Assert.*
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.4.21"
+    ext.spotless_version = "5.11.0"
     repositories {
         google()
         jcenter()
@@ -8,7 +9,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotless_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/pre-commit
+++ b/pre-commit
@@ -18,6 +18,7 @@ then
     exit 1
 fi
 
+./gradlew spotlessCheck
 
 RESULT=$?
 

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,0 +1,16 @@
+apply plugin: "com.diffplug.spotless"
+
+spotless {
+    kotlin {
+        target '**/*.kt'
+        ktlint("0.37.2").userData(['disabled_rules': 'no-wildcard-imports'])
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+    }
+
+    java {
+        target 'src/*/java/**/*.java'
+        googleJavaFormat('1.8').aosp()
+    }
+}


### PR DESCRIPTION
 1. spotless check task will now run on every pre-commit hook execution.
 2. code formatting rules can be added in spotless.gradle file.
 3. applying fixes can be performed using `./gradlew spotlessApply` command.